### PR TITLE
Single comment for coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Store Pull Request comment to be posted
         uses: actions/upload-artifact@v4
-        if: steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true'
+        if: steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true' && ${{ matrix.python-version }} == "3.11"
         with:
           # If you use a different name, update COMMENT_ARTIFACT_NAME accordingly
           name: python-coverage-comment-action

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Coverage comment
         id: coverage_comment
         uses: py-cov-action/python-coverage-comment-action@v3
+        if: ${{ matrix.python-version }} == "3.11"
         with:
           GITHUB_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
Limit the publication of coverage comments to only a single python version to avoid spam.