### PR TITLE
Reorganize the coverage trigger.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,22 +38,6 @@ jobs:
           source venv/bin/activate
           pip3 install -r requirements.txt
           pip3 install -e .
-          pytest tests/ --cov=lammpsinputbuilder
+          pytest tests/
           deactivate
         working-directory: ${{ github.workspace }}
-
-      - name: Coverage comment
-        id: coverage_comment
-        uses: py-cov-action/python-coverage-comment-action@v3
-        if: ${{ matrix.python-version }} == "3.11"
-        with:
-          GITHUB_TOKEN: ${{ github.token }}
-
-      - name: Store Pull Request comment to be posted
-        uses: actions/upload-artifact@v4
-        if: steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true' && ${{ matrix.python-version }} == "3.11"
-        with:
-          # If you use a different name, update COMMENT_ARTIFACT_NAME accordingly
-          name: python-coverage-comment-action
-          # If you use a different name, update COMMENT_FILENAME accordingly
-          path: python-coverage-comment-action.txt

--- a/.github/workflows/cov.yaml
+++ b/.github/workflows/cov.yaml
@@ -7,7 +7,7 @@ on:
       - "main"
 
 jobs:
-  pylint-check:
+  coverage_check:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/cov.yaml
+++ b/.github/workflows/cov.yaml
@@ -1,0 +1,60 @@
+name: COV
+
+on:
+  pull_request:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  pylint-check:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Create virtual environment
+      run: python -m venv venv
+      working-directory: ${{ github.workspace }}
+
+    - name: Activate virtual environment and install dependencies
+      run: |
+        source venv/bin/activate
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip3 install -e .
+        deactivate
+      working-directory: ${{ github.workspace }}
+
+    - name: Perform code coverage
+      run: |
+        source venv/bin/activate
+        pytest tests/ --cov=lammpsinputbuilder
+        deactivate
+      working-directory: ${{ github.workspace }} 
+
+    - name: Coverage comment
+      id: coverage_comment
+      uses: py-cov-action/python-coverage-comment-action@v3
+      with:
+        GITHUB_TOKEN: ${{ github.token }}
+
+    - name: Store Pull Request comment to be posted
+      uses: actions/upload-artifact@v4
+      if: steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true'
+      with:
+        # If you use a different name, update COMMENT_ARTIFACT_NAME accordingly
+        name: python-coverage-comment-action
+        # If you use a different name, update COMMENT_FILENAME accordingly
+        path: python-coverage-comment-action.txt
+
+

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -3,7 +3,7 @@ name: Post coverage comment
 
 on:
   workflow_run:
-    workflows: ["CI"]
+    workflows: ["COV"]
     types:
       - completed
 


### PR DESCRIPTION
Split the coverage pytest to its own pipeline rather than the general pytest with the different python versions.